### PR TITLE
Fixed `ModuleNotFoundError` when not installing AWS dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Nautobot Secrets Providers Changelog
 
+## v1.0.1 (2022-01-06)
+
+### Fixed
+
+- [#17](https://github.com/nautobot/nautobot-plugin-secrets-providers/issues/17) Fixed `ModuleNotFoundError` when not installing AWS dependencies
+
 ## v1.0.0 (2021-12-22)
 
 This is the initial release of Nautobot Secrets Providers that includes support for basic key-value secrets AWS Secrets Manager and HashiCorp Vault. Please see [README.md](./README.md) for more information.

--- a/nautobot_secrets_providers/providers/aws.py
+++ b/nautobot_secrets_providers/providers/aws.py
@@ -5,9 +5,10 @@ import json
 
 try:
     import boto3
-except ImportError:
+    from botocore.exceptions import ClientError
+except (ImportError, ModuleNotFoundError):
     boto3 = None
-from botocore.exceptions import ClientError
+
 from django import forms
 
 from nautobot.utilities.forms import BootstrapMixin


### PR DESCRIPTION
## Fixes #17 

This will import `boto3` and `botocore` in the same `try...except` block and if either of them fail, `boto3` will be set to `None`.