### PR TITLE
Add support of mount point feature for HashiCorp Vault provider

### DIFF
--- a/nautobot_secrets_providers/providers/hashicorp.py
+++ b/nautobot_secrets_providers/providers/hashicorp.py
@@ -59,7 +59,10 @@ class HashiCorpVaultSecretsProvider(SecretsProvider):
         try:
             secret_path = parameters["path"]
             secret_key = parameters["key"]
-            secret_mount_point = parameters["mount_point"]
+            if "mount_point" in parameters:
+                secret_mount_point = parameters["mount_point"]
+            else:
+                secret_mount_point = DEFAULT_MOUNT_POINT
         except KeyError as err:
             msg = f"The secret parameter could not be retrieved for field {err}"
             raise exceptions.SecretParametersError(secret, cls, msg) from err

--- a/nautobot_secrets_providers/providers/hashicorp.py
+++ b/nautobot_secrets_providers/providers/hashicorp.py
@@ -37,7 +37,7 @@ class HashiCorpVaultSecretsProvider(SecretsProvider):
         )
         mount_point = forms.CharField(
             required=False,
-            help_text=f"The path where the secret engine was mounted on (default value: {DEFAULT_MOUNT_POINT})",
+            help_text=f"The path where the secret engine was mounted on (Default: <code>{DEFAULT_MOUNT_POINT}</code>)",
             initial=DEFAULT_MOUNT_POINT,
         )
 
@@ -59,10 +59,7 @@ class HashiCorpVaultSecretsProvider(SecretsProvider):
         try:
             secret_path = parameters["path"]
             secret_key = parameters["key"]
-            if "mount_point" in parameters:
-                secret_mount_point = parameters["mount_point"]
-            else:
-                secret_mount_point = DEFAULT_MOUNT_POINT
+            secret_mount_point = parameters.get("mount_point", DEFAULT_MOUNT_POINT)
         except KeyError as err:
             msg = f"The secret parameter could not be retrieved for field {err}"
             raise exceptions.SecretParametersError(secret, cls, msg) from err

--- a/nautobot_secrets_providers/providers/hashicorp.py
+++ b/nautobot_secrets_providers/providers/hashicorp.py
@@ -5,6 +5,7 @@ from django.conf import settings
 
 try:
     import hvac
+
     DEFAULT_MOUNT_POINT = hvac.api.secrets_engines.kv_v2.DEFAULT_MOUNT_POINT
 except ImportError:
     hvac = None
@@ -37,7 +38,7 @@ class HashiCorpVaultSecretsProvider(SecretsProvider):
         mount_point = forms.CharField(
             required=False,
             help_text=f"The path where the secret engine was mounted on (default value: {DEFAULT_MOUNT_POINT})",
-            initial=DEFAULT_MOUNT_POINT
+            initial=DEFAULT_MOUNT_POINT,
         )
 
     @classmethod

--- a/nautobot_secrets_providers/tests/test_providers.py
+++ b/nautobot_secrets_providers/tests/test_providers.py
@@ -134,7 +134,15 @@ class HashiCorpVaultSecretsProviderTestCase(SecretsProviderTestCase):
             provider=self.provider.slug,
             parameters={"path": "hello", "key": "location"},
         )
+        # The secret with a mounting point we be using.
+        self.secret_mounting_point = Secret.objects.create(
+            name="hello-hashicorp-mntpnt",
+            slug="hello-hashicorp-mntpnt",
+            provider=self.provider.slug,
+            parameters={"path": "hello", "key": "location", "mount_point": "mymount"},
+        )
         self.test_path = "http://localhost:8200/v1/secret/data/hello"
+        self.test_mountpoint_path = "http://localhost:8200/v1/mymount/data/hello"
 
     @requests_mock.Mocker()
     def test_retrieve_success(self, requests_mocker):
@@ -142,6 +150,14 @@ class HashiCorpVaultSecretsProviderTestCase(SecretsProviderTestCase):
         requests_mocker.register_uri(method="GET", url=self.test_path, json=self.mock_response)
 
         response = self.provider.get_value_for_secret(self.secret)
+        self.assertEqual(self.mock_response["data"]["data"]["location"], response)
+
+    @requests_mock.Mocker()
+    def test_retrieve_mount_point_success(self, requests_mocker):
+        """Retrieve a secret successfully."""
+        requests_mocker.register_uri(method="GET", url=self.test_mountpoint_path, json=self.mock_response)
+
+        response = self.provider.get_value_for_secret(self.secret_mounting_point)
         self.assertEqual(self.mock_response["data"]["data"]["location"], response)
 
     @requests_mock.Mocker()

--- a/nautobot_secrets_providers/tests/test_providers.py
+++ b/nautobot_secrets_providers/tests/test_providers.py
@@ -154,7 +154,7 @@ class HashiCorpVaultSecretsProviderTestCase(SecretsProviderTestCase):
 
     @requests_mock.Mocker()
     def test_retrieve_mount_point_success(self, requests_mocker):
-        """Retrieve a secret successfully."""
+        """Retrieve a secret successfully using a custom `mount_point`."""
         requests_mocker.register_uri(method="GET", url=self.test_mountpoint_path, json=self.mock_response)
 
         response = self.provider.get_value_for_secret(self.secret_mounting_point)


### PR DESCRIPTION
issue #23 

I'm adding the possibility to specify the mounting point for Hashicorp Vault.
More info about mounting vault : https://learn.hashicorp.com/tutorials/vault/namespace-structure?in=vault/enterprise#understand-vault-s-mount-points

Why supporting mount point ?
If we enable a new KV engine, it will create another mounting point which is not accessible on "secret/" mounting point.
![image](https://user-images.githubusercontent.com/1486562/159676399-fe8c7f86-8e7f-4a5e-bdd3-7c3dcc3cba5a.png)

