### PR TITLE
Allow default mount point in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ PLUGINS_CONFIG = {
 - `url` - (required) The URL to the HashiCorp Vault instance (e.g. `http://localhost:8200`).
 - `auth_method` - (optional / defaults to "token") The method used to authenticate against the HashiCorp Vault instance. Either `"approle"`, `"aws"`, `"kubernetes"` or `"token"`.  For information on using AWS authentication with vault see the [authentication](#authentication) section above.
 - `ca_cert` - (optional) Path to a PEM formatted CA certificate to use when verifying the Vault connection.  Can alternatively be set to `False` to ignore SSL verification (not recommended) or `True` to use the system certificates.
+- `default_mount_point` - (optional / defaults to "secret") The default mount point of the K/V Version 2 secrets engine within Hashicorp Vault.
 - `k8s_token_path` - (optional) Path to the kubernetes service account token file.  Defaults to "/var/run/secrets/kubernetes.io/serviceaccount/token".
 - `token` - (optional) Required when `"auth_method": "token"` or `auth_method` is not supplied. The token for authenticating the client with the HashiCorp Vault instance. As with other sensitive service credentials, we recommend that you provide the token value as an environment variable and retrieve it with `{"token": os.getenv("NAUTOBOT_HASHICORP_VAULT_TOKEN")}` rather than hard-coding it in your `nautobot_config.py`.
 - `role_name` - (optional) Required when `"auth_method": "kubernetes"`, optional when `"auth_method": "aws"`.  The Vault Kubernetes role or Vault AWS role to assume which the pod's service account has access to.

--- a/nautobot_secrets_providers/providers/hashicorp.py
+++ b/nautobot_secrets_providers/providers/hashicorp.py
@@ -23,7 +23,11 @@ AUTH_METHOD_CHOICES = ["approle", "aws", "kubernetes", "token"]
 
 
 # Default mount point for the HVAC client
-DEFAULT_MOUNT_POINT = "secret"
+try:
+    plugins_config = settings.PLUGINS_CONFIG["nautobot_secrets_providers"]
+    DEFAULT_MOUNT_POINT = plugins_config["hashicorp_vault"]["default_mount_point"]
+except KeyError:
+    DEFAULT_MOUNT_POINT = "secret"
 
 
 class HashiCorpVaultSecretsProvider(SecretsProvider):


### PR DESCRIPTION
Fixes: #40 

Adds the `default_mount_point` config option for vault.