### PR TITLE
Update Thycotic to Delinea

### DIFF
--- a/development/creds.example.env
+++ b/development/creds.example.env
@@ -17,8 +17,8 @@ REDIS_PASSWORD=notverysecurepwd
 # NAUTOBOT_ROOT=./development
 
 #############################################################################
-# Settings for Thycotic Secret-Server-Reader
-#     https://github.com/thycotic/python-tss-sdk
+# Settings for Delinea/Thycotic Secret-Server-Reader
+#     https://github.com/DelineaXPM/python-tss-sdk
 
 SECRET_SERVER_BASE_URL='https://pw.example.local/SecretServer'
 


### PR DESCRIPTION
Update Links and Comments to reflect the change to Delinea Repository from Thycotic in `creds.example.env`