### PR TITLE
Updates to install on Nautobot 2.0 Alpha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.8"]
-        nautobot-version: ["1.4.10"]
+        nautobot-version: ["next"]
     env:
       INVOKE_NAUTOBOT_SECRETS_PROVIDERS_PYTHON_VER: "${{ matrix.python-version }}"
       INVOKE_NAUTOBOT_SECRETS_PROVIDERS_NAUTOBOT_VER: "${{ matrix.nautobot-version }}"
@@ -112,7 +112,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        nautobot-version: ["1.4.10", "1.5.10"]
+        nautobot-version: ["next"]
     runs-on: "ubuntu-20.04"
     env:
       INVOKE_NAUTOBOT_SECRETS_PROVIDERS_PYTHON_VER: "${{ matrix.python-version }}"

--- a/nautobot_secrets_providers/__init__.py
+++ b/nautobot_secrets_providers/__init__.py
@@ -21,7 +21,7 @@ class NautobotSecretsProvidersConfig(PluginConfig):
     description = "Nautobot App that provides direct integrations with Enterprise secrets management systems. Provides patterns to securely fetch secrets for use by other Nautobot Apps and Nautobot Jobs."
     base_url = "secrets"
     required_settings = []
-    min_version = "1.4.0"
+    min_version = "2.0.0-alpha.1"
     default_settings = {}
     caching_config = {}
 

--- a/nautobot_secrets_providers/__init__.py
+++ b/nautobot_secrets_providers/__init__.py
@@ -22,7 +22,6 @@ class NautobotSecretsProvidersConfig(PluginConfig):
     base_url = "secrets"
     required_settings = []
     min_version = "1.4.0"
-    max_version = "1.9999"
     default_settings = {}
     caching_config = {}
 

--- a/nautobot_secrets_providers/providers/aws.py
+++ b/nautobot_secrets_providers/providers/aws.py
@@ -11,7 +11,7 @@ except (ImportError, ModuleNotFoundError):
 
 from django import forms
 
-from nautobot.utilities.forms import BootstrapMixin
+from nautobot.core.forms import BootstrapMixin
 from nautobot.extras.secrets import exceptions, SecretsProvider
 
 

--- a/nautobot_secrets_providers/providers/choices.py
+++ b/nautobot_secrets_providers/providers/choices.py
@@ -1,5 +1,5 @@
 """Choices for Thycotic Secret Server Plugin."""
-from nautobot.utilities.choices import ChoiceSet
+from nautobot.core.choices import ChoiceSet
 
 
 class ThycoticSecretChoices(ChoiceSet):

--- a/nautobot_secrets_providers/providers/delinea.py
+++ b/nautobot_secrets_providers/providers/delinea.py
@@ -33,7 +33,7 @@ except ImportError:
     except ImportError:
         thycotic_installed = False  # pylint: disable=invalid-name
 
-from nautobot.utilities.forms import BootstrapMixin
+from nautobot.core.forms import BootstrapMixin
 from nautobot.extras.secrets import exceptions, SecretsProvider
 
 from .choices import ThycoticSecretChoices

--- a/nautobot_secrets_providers/providers/hashicorp.py
+++ b/nautobot_secrets_providers/providers/hashicorp.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     hvac = None
 
-from nautobot.utilities.forms import BootstrapMixin
+from nautobot.core.forms import BootstrapMixin
 from nautobot.extras.secrets import exceptions, SecretsProvider
 
 __all__ = ("HashiCorpVaultSecretsProvider",)


### PR DESCRIPTION
- Replaced `nautobot.utilities` imports with `nautobot.core`
