### PR TITLE
Fixing Null AWS Region

### DIFF
--- a/nautobot_secrets_providers/providers/hashicorp.py
+++ b/nautobot_secrets_providers/providers/hashicorp.py
@@ -152,7 +152,8 @@ class HashiCorpVaultSecretsProvider(SecretsProvider):
                     session = boto3.Session()
                     aws_creds = session.get_credentials()
                     aws_region = session.region_name
-                    if session.region_name is None: aws_region = 'us-east-1'
+                    if session.region_name is None:
+                        aws_region = "us-east-1"
                     client.auth.aws.iam_login(
                         access_key=aws_creds.access_key,
                         secret_key=aws_creds.secret_key,

--- a/nautobot_secrets_providers/providers/hashicorp.py
+++ b/nautobot_secrets_providers/providers/hashicorp.py
@@ -152,7 +152,7 @@ class HashiCorpVaultSecretsProvider(SecretsProvider):
                     session = boto3.Session()
                     aws_creds = session.get_credentials()
                     aws_region = session.region_name
-                    if session.region_name is None:
+                    if aws_region is None:
                         aws_region = "us-east-1"
                     client.auth.aws.iam_login(
                         access_key=aws_creds.access_key,

--- a/nautobot_secrets_providers/providers/hashicorp.py
+++ b/nautobot_secrets_providers/providers/hashicorp.py
@@ -155,7 +155,6 @@ class HashiCorpVaultSecretsProvider(SecretsProvider):
                         access_key=aws_creds.access_key,
                         secret_key=aws_creds.secret_key,
                         session_token=aws_creds.token,
-                        region=session.region_name,
                         role=vault_settings.get("role_name", None),
                         **login_kwargs,
                     )

--- a/nautobot_secrets_providers/providers/hashicorp.py
+++ b/nautobot_secrets_providers/providers/hashicorp.py
@@ -151,10 +151,13 @@ class HashiCorpVaultSecretsProvider(SecretsProvider):
                 elif auth_method == "aws":
                     session = boto3.Session()
                     aws_creds = session.get_credentials()
+                    aws_region = session.region_name
+                    if session.region_name is None: aws_region = 'us-east-1'
                     client.auth.aws.iam_login(
                         access_key=aws_creds.access_key,
                         secret_key=aws_creds.secret_key,
                         session_token=aws_creds.token,
+                        region=aws_region,
                         role=vault_settings.get("role_name", None),
                         **login_kwargs,
                     )


### PR DESCRIPTION
Fixes: #91

I manually stepped through the code on an AWS instance with an IAM role to authenticate with Vault.  I was able to reproduce the error.  Turns out the region `session.region_name` from boto3 can be `None`.  The region parameter is not needed for `iam_login` and therefore I suggest simply removing it as it is already possible to add additional kwargs via the config.