### PR TITLE
Relax dependency requirement on boto3 library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-boto3 = { version = "~1.19.5", optional = true }
+boto3 = { version = "^1.19.5", optional = true }
 hvac = { version = ">=0.11.0, <1.1.0", optional = true }
 nautobot = "^2.0.0"
 python = ">=3.8,<3.12"


### PR DESCRIPTION
boto3 moves fairly quickly and we have it pinned to a specific major version, I think this can be safely relaxed.